### PR TITLE
fix: resolved typo on `image_repository_name`

### DIFF
--- a/azure-devops/nodo/06_pagopa-nodo-re-to-datastore.tf
+++ b/azure-devops/nodo/06_pagopa-nodo-re-to-datastore.tf
@@ -51,7 +51,7 @@ locals {
     uat_container_registry_service_conn  = data.terraform_remote_state.app.outputs.service_endpoint_azure_devops_acr_aks_uat_id
     prod_container_registry_service_conn = data.terraform_remote_state.app.outputs.service_endpoint_azure_devops_acr_aks_prod_id
 
-    image_repository_name = replace(var.pagopa-nodo-re-to-tablestorage.repository.name, "-", "")
+    image_repository_name = replace(var.pagopa-nodo-re-to-datastore.repository.name, "-", "")
 
     dev_container_namespace  = "pagopadcommonacr.azurecr.io"
     uat_container_namespace  = "pagopaucommonacr.azurecr.io"


### PR DESCRIPTION
This PR contains a resolution that resolves a typo on `nodo-re-to-datastore` Function deployment: the function was pointing towards the Docker image related to the `nodo-re-to-tablestorage` Function, installing this last application for two time in two different function apps. 

### List of changes
 - Resolved typo on variable

### Motivation and context
This change is required in order to resolve the wrong deploy of  `nodo-re-to-datastore` Function.

### Type of changes
- [ ] Add new pipeline
- [x] Update pipeline configuration
- [ ] Remove pipeline

### :warning: If it's new pipeline with code review have you added pagopa-github-bot -> Role: admin?
- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
