### PR TITLE
feat: PAYMCLOUD-271 external tls cert: update service connection

### DIFF
--- a/azure-devops/externals/.terraform.lock.hcl
+++ b/azure-devops/externals/.terraform.lock.hcl
@@ -2,112 +2,101 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/azuread" {
-  version     = "2.47.0"
-  constraints = ">= 2.10.0"
+  version     = "2.53.1"
+  constraints = "~> 2.50, ~> 2.51"
   hashes = [
-    "h1:iRwDQBdXBpVBoYwM9au2RG01RQuJSm3TGQ2kioFVAas=",
-    "zh:1372d81eb24ef3b4b00ea350fe87219f22da51691b8e42ce91d662f6c2a8af5e",
+    "h1:EZNO8sEtUABuRxujQrDrW1z1QsG0dq6iLbzWtnG7Om4=",
+    "zh:162916b037e5133f49298b0ffa3e7dcef7d76530a8ca738e7293373980f73c68",
     "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
-    "zh:1e654a74d171d6ff8f9f6f67e3ff1421d4c5e56a18607703626bf12cd23ba001",
-    "zh:35227fad617a0509c64ab5759a8b703b10d244877f1aa5416bfbcc100c96996f",
-    "zh:357f553f0d78d46a96c7b2ed06d25ee0fc60fc5be19812ccb5d969fa47d62e17",
-    "zh:58faa2940065137e3e87d02eba59ab5cd7137d7a18caf225e660d1788f274569",
-    "zh:7308eda0339620fa24f47cedd22221fc2c02cab9d5be1710c09a783aea84eb3a",
-    "zh:863eabf7f908a8263e28d8aa2ad1381affd6bb5c67755216781f674ef214100e",
-    "zh:8b95b595a7c14ed7b56194d03cdec253527e7a146c1c58961be09e6b5c50baee",
-    "zh:afbca6b4fac9a0a488bc22ff9e51a8f14e986137d25275068fd932f379a51d57",
-    "zh:c6aadec4c81a44c3ffc22c2d90ffc6706bf5a9a903a395d896477516f4be6cbb",
-    "zh:e54a59de7d4ef0f3a18f91fed0b54a2bce18257ae2ee1df8a88226e1023c5811",
+    "zh:492931cea4f30887ab5bca36a8556dfcb897288eddd44619c0217fc5da2d57e7",
+    "zh:4c895e450e18335ad8714cc6d3488fc1a78816ad2851a91b06cb2ef775dd7c66",
+    "zh:60d92fdaf7235574201f2d8f68f733ee00a822993b3fc95e6952e09e6ec76999",
+    "zh:67a169119efa41c1fb867ef1a8e79bf03472a2324384c36eb55370c817dcce42",
+    "zh:9dd4d5ed9233cf9329262200bc5a1aa60942b80dbc611e2ef4b09f47531b39b1",
+    "zh:a3c160e35b9e40fc1497b83c2f37a8e24565b05a1783c7733609f3695735c2a9",
+    "zh:a4a221da42b1f46e7c436c7145e5beaadfd9d03f3be6fd526d132c03f18a5979",
+    "zh:af0d3476a9702d2287e168e3baa670e64daab9c9b01c01e17025a5248f3e28e9",
+    "zh:e3579bff7894f3d36066b74ec324be6d28f56a42a387a2b8a0eabf33cbff86df",
+    "zh:f1749ee8ad972ae6424665aa9d2c0ece8c40c51d41ec2f38b863148cb437e865",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/azurerm" {
-  version     = "3.71.0"
-  constraints = ">= 3.30.0, <= 3.71.0, <= 3.85.0"
+  version     = "3.117.0"
+  constraints = "~> 3.30, ~> 3.101, ~> 3.107"
   hashes = [
-    "h1:ObZdNLRtZhIaWWs2ceZjFfu8tzxh9lEJfbXUSDOeaQk=",
-    "h1:QI0iaPNi0qAOIbXptd4ZObi0D5X1jojom5774GtEspA=",
-    "h1:nTc6DFS9euNgUkNylQ/AxNYN9Ln1dyL+WVIBNcict7Y=",
-    "h1:vhmOvVQgCyxXeS25wKuPTNpOAAtocPj5faL1yFS/Bcc=",
-    "h1:xySu+5dS0H9KYVsQoFp61uc5XLRKif9FrFs//OPNDrM=",
-    "zh:06f0d225b1711dfad256ff33134f878acc8f84624d9da66b075b075cc4d75892",
-    "zh:09ff74056818babe02ea5a633bffe2b8223eaf79916dc1db169651ef7725c22f",
-    "zh:27687e0f8458e6d88ebea94352eb523f56e8f5cdc468268af8f38dc4a4265bf4",
-    "zh:2d81bfab3c6a9b897fa8fbb5256c9e5a944e6ecbf7f73a2a3e2b53a2c4fbcfc5",
-    "zh:4cfc744cfc37aeeeecd82800c70e2591b38447af9e3c51bcbf06a5efe842ed65",
-    "zh:734fbb81508b264f772a076338ddf1c7b25534d2007a1738a7d55587478ed258",
-    "zh:9a5502c364f58073599fff8cdd8adc32e7f7bcd00a4d9b57d2fff678fd8a8319",
-    "zh:9bc528f7e78dbfd106f94b741b68dedd3dd3d31c3defcddcc1972c8e52a6b7db",
-    "zh:c30db03d877f9a7ae0c19d3fd338bbf95cdddbf6df1023709dbfa99689abac14",
-    "zh:c51d4065145b8f4ca45fc9a0f3ca7f2d933bc0302af2eead74f3ce64a9221ae8",
-    "zh:e23029fc7f81723795d7da770131adb1ce6f4d32f0a57eb75d47e036a0a19833",
+    "h1:pAXy9cKU+bX1rvWog4YWeLbg7VFHqRTAFKbjayIXK1k=",
+    "zh:2e25f47492366821a786762369f0e0921cc9452d64bfd5075f6fdfcf1a9c6d70",
+    "zh:41eb34f2f7469bf3eb1019dfb0e7fc28256f809824016f4f8b9d691bf473b2ac",
+    "zh:48bb9c87b3d928da1abc1d3db75453c9725de4674c612daf3800160cc7145d30",
+    "zh:5d6b0de0bbd78943fcc65c53944ef4496329e247f434c6eab86ed051c5cea67b",
+    "zh:78c9f6fdb1206a89cf0e6706b4f46178169a93b6c964a4cad8a321058ccbd9b4",
+    "zh:793b702c352589d4360b580d4a1cf654a7439d2ad6bdb7bfea91de07bc4b0fac",
+    "zh:7ed687ff0a5509463a592f97431863574fe5cc80a34e395be06766215b8c6285",
+    "zh:955ba18789bd15592824eb426a8d0f38595bd09fffc6939c1c58933489c1a71e",
+    "zh:bf5949a55be0714cd9c8815d472eae4baa48ba06d0f6bf2b96775869acda8a54",
+    "zh:da5d31f635abd2c645ffc76d6176d73f646128e73720cc368247cc424975c127",
+    "zh:eed5a66d59883c9c56729b0a964a2b60d758ea7489ef3e920a6fbd48518ce5f5",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/null" {
-  version     = "3.2.2"
-  constraints = ">= 1.3.0"
+  version     = "3.2.3"
+  constraints = "~> 3.2"
   hashes = [
-    "h1:vWAsYRd7MjYr3adj8BVKRohVfHpWQdvkIwUQ2Jf5FVM=",
-    "zh:3248aae6a2198f3ec8394218d05bd5e42be59f43a3a7c0b71c66ec0df08b69e7",
-    "zh:32b1aaa1c3013d33c245493f4a65465eab9436b454d250102729321a44c8ab9a",
-    "zh:38eff7e470acb48f66380a73a5c7cdd76cc9b9c9ba9a7249c7991488abe22fe3",
-    "zh:4c2f1faee67af104f5f9e711c4574ff4d298afaa8a420680b0cb55d7bbc65606",
-    "zh:544b33b757c0b954dbb87db83a5ad921edd61f02f1dc86c6186a5ea86465b546",
-    "zh:696cf785090e1e8cf1587499516b0494f47413b43cb99877ad97f5d0de3dc539",
-    "zh:6e301f34757b5d265ae44467d95306d61bef5e41930be1365f5a8dcf80f59452",
+    "h1:I0Um8UkrMUb81Fxq/dxbr3HLP2cecTH2WMJiwKSrwQY=",
+    "zh:22d062e5278d872fe7aed834f5577ba0a5afe34a3bdac2b81f828d8d3e6706d2",
+    "zh:23dead00493ad863729495dc212fd6c29b8293e707b055ce5ba21ee453ce552d",
+    "zh:28299accf21763ca1ca144d8f660688d7c2ad0b105b7202554ca60b02a3856d3",
+    "zh:55c9e8a9ac25a7652df8c51a8a9a422bd67d784061b1de2dc9fe6c3cb4e77f2f",
+    "zh:756586535d11698a216291c06b9ed8a5cc6a4ec43eee1ee09ecd5c6a9e297ac1",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:913a929070c819e59e94bb37a2a253c228f83921136ff4a7aa1a178c7cce5422",
-    "zh:aa9015926cd152425dbf86d1abdbc74bfe0e1ba3d26b3db35051d7b9ca9f72ae",
-    "zh:bb04798b016e1e1d49bcc76d62c53b56c88c63d6f2dfe38821afef17c416a0e1",
-    "zh:c23084e1b23577de22603cff752e59128d83cfecc2e6819edadd8cf7a10af11e",
+    "zh:9d5eea62fdb587eeb96a8c4d782459f4e6b73baeece4d04b4a40e44faaee9301",
+    "zh:a6355f596a3fb8fc85c2fb054ab14e722991533f87f928e7169a486462c74670",
+    "zh:b5a65a789cff4ada58a5baffc76cb9767dc26ec6b45c00d2ec8b1b027f6db4ed",
+    "zh:db5ab669cf11d0e9f81dc380a6fdfcac437aea3d69109c7aef1a5426639d2d65",
+    "zh:de655d251c470197bcbb5ac45d289595295acb8f829f6c781d4a75c8c8b7c7dd",
+    "zh:f5c68199f2e6076bce92a12230434782bf768103a427e9bb9abee99b116af7b5",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/time" {
-  version     = "0.10.0"
-  constraints = ">= 0.7.0"
+  version     = "0.12.1"
+  constraints = "~> 0.10, ~> 0.11"
   hashes = [
-    "h1:EeF/Lb4db1Kl1HEHzT1StTC7RRqHn/eB7aDR3C3yjVg=",
-    "h1:NAl8eupFAZXCAbE5uiHZTz+Yqler55B3fMG+jNPrjjM=",
-    "h1:QL1ivYrUSB3zvhgXcRBfQak4HDxvesT2zktM+N6StVo=",
-    "h1:rPbqd7mEyBetQPjyBDBAdwiARulKbh2LwzQp2GSl/AI=",
-    "zh:0ab31efe760cc86c9eef9e8eb070ae9e15c52c617243bbd9041632d44ea70781",
-    "zh:0ee4e906e28f23c598632eeac297ab098d6d6a90629d15516814ab90ad42aec8",
-    "zh:3bbb3e9da728b82428c6f18533b5b7c014e8ff1b8d9b2587107c966b985e5bcc",
-    "zh:6771c72db4e4486f2c2603c81dfddd9e28b6554d1ded2996b4cb37f887b467de",
+    "h1:JzYsPugN8Fb7C4NlfLoFu7BBPuRVT2/fCOdCaxshveI=",
+    "zh:090023137df8effe8804e81c65f636dadf8f9d35b79c3afff282d39367ba44b2",
+    "zh:26f1e458358ba55f6558613f1427dcfa6ae2be5119b722d0b3adb27cd001efea",
+    "zh:272ccc73a03384b72b964918c7afeb22c2e6be22460d92b150aaf28f29a7d511",
+    "zh:438b8c74f5ed62fe921bd1078abe628a6675e44912933100ea4fa26863e340e9",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:833c636d86c2c8f23296a7da5d492bdfd7260e22899fc8af8cc3937eb41a7391",
-    "zh:c545f1497ae0978ffc979645e594b57ff06c30b4144486f4f362d686366e2e42",
-    "zh:def83c6a85db611b8f1d996d32869f59397c23b8b78e39a978c8a2296b0588b2",
-    "zh:df9579b72cc8e5fac6efee20c7d0a8b72d3d859b50828b1c473d620ab939e2c7",
-    "zh:e281a8ecbb33c185e2d0976dc526c93b7359e3ffdc8130df7422863f4952c00e",
-    "zh:ecb1af3ae67ac7933b5630606672c94ec1f54b119bf77d3091f16d55ab634461",
-    "zh:f8109f13e07a741e1e8a52134f84583f97a819e33600be44623a21f6424d6593",
+    "zh:85c8bd8eefc4afc33445de2ee7fbf33a7807bc34eb3734b8eefa4e98e4cddf38",
+    "zh:98bbe309c9ff5b2352de6a047e0ec6c7e3764b4ed3dfd370839c4be2fbfff869",
+    "zh:9c7bf8c56da1b124e0e2f3210a1915e778bab2be924481af684695b52672891e",
+    "zh:d2200f7f6ab8ecb8373cda796b864ad4867f5c255cff9d3b032f666e4c78f625",
+    "zh:d8c7926feaddfdc08d5ebb41b03445166df8c125417b28d64712dccd9feef136",
+    "zh:e2412a192fc340c61b373d6c20c9d805d7d3dee6c720c34db23c2a8ff0abd71b",
+    "zh:e6ac6bba391afe728a099df344dbd6481425b06d61697522017b8f7a59957d44",
   ]
 }
 
 provider "registry.terraform.io/microsoft/azuredevops" {
-  version     = "0.10.0"
-  constraints = ">= 0.10.0, ~> 0.10.0, <= 0.12.0"
+  version     = "1.7.0"
+  constraints = "~> 1.1"
   hashes = [
-    "h1:GazdScTk4i4y9aIsvsO7GYkHYPYJBfaddaU+VlkLnZg=",
-    "h1:GwFmEDohB4JeBGMMvSOdSw7SHxh1xZqQUfko7eaW+l4=",
-    "h1:Hj5nF4BkL7C3VC4270+xVaQblQ7Men67kOVsyzGIDiU=",
-    "h1:l8Ca3XYkTJSAFprCetXq1vtz2+m+DgZsmIJDIoEEP18=",
-    "h1:pQ5DtCrsBqk+HySLc+esk+9qwl2ZW6MaQ0d2zLUjDQo=",
-    "zh:07e596c045f8ee411c630e29e180e946d5e75af615e0223877de9c4718ff0265",
-    "zh:18c07b7b610a85079b510117296da1fe2cd99da3664ece2a98390329dac2b58a",
-    "zh:220949b1271420864d324f0494739b70ed79f66ad3d2928d9acb804bc04d1e75",
-    "zh:28638f4105ffe8db80fee3ac10de93b79e6e6812473f53e216c495e6a16151b5",
-    "zh:28a1882bbc8fa1b0eea908623ac6d45aa15757ca96b0a7acc784fc64e92d8ad9",
-    "zh:3dbed2631472baa0b38fb8ce644436f8e9373e650644d8b99ad372ad69733dca",
-    "zh:4662e1e782b25c29aa93f76d8182af8ef54798289219d4085715b53628365eda",
-    "zh:878caf183e77fbd3771fdb9c1e007ab8783ff47b6b383dee4d0a82f10d3a0c21",
-    "zh:bb021e2450534c3a47c4960bd91ccb36b8d68dab5fc172a70aaa3562f94607fa",
-    "zh:cc6eda6ae28755521a62545ca1a04423672756edd7370542101c5963b6a248f1",
-    "zh:fa50613fec6b8fc856810b80846bba32030dd5163c034061b667897851ff1c4e",
-    "zh:ffc9d217b9c1db1a4cbcd6d2d28360821145fa8e1d31c5c00d29128044018c31",
+    "h1:yqnMqDJE+93zgp/+7913o0TbnLRxknjwrdKaC4n6AVI=",
+    "zh:0cf9215b82ab2bd80c02acecdfe3afb5c219609bb11bd1407eab863658694575",
+    "zh:11a7cc40484f9fef3a5162d8679cf1b203216c630f76ad3bdf1e0d4e6b8cda95",
+    "zh:527346ec1be9d6e9c26c432c6fdf4efcb4e6adc60139ce78693aefe79965c596",
+    "zh:731bb275d7ae33d539f4e7be8ee57a3afdb1f0807b381d783f0ef161dc277ea3",
+    "zh:7946c7410958623118828e4235b7f9ee3bb1f126282536208ead0e258a1202c6",
+    "zh:861fd1caa003ee51701bf6569d2baa62d6445a7a954efc17d066ed0e7e363694",
+    "zh:87bafe93de38afda736f24bef6985ee1dc818860c74882ad58d2256118d1f2f5",
+    "zh:9b494c34c01c2107b32ab9a8f94439a8c722e26428ab0e71e70bdf4b4febe0ff",
+    "zh:adc34195860e7bbc114e18106c93ac8e1c73921c177273145a653a2447ae9023",
+    "zh:bac2694919d6276d1905c9f17258e0f145c100eeb9ad98d54c2bfad70ef51857",
+    "zh:c4d1afecad2ea93177fd403d92c91d0bc5233e9322ee8ae92aa805d218cadb2c",
+    "zh:eceaf6b53ad46437b63439ec36c3bfba25e06c3330ebb478b9615707d4e6d2e3",
   ]
 }

--- a/azure-devops/externals/00_secrets_dev.tf
+++ b/azure-devops/externals/00_secrets_dev.tf
@@ -1,5 +1,5 @@
 module "pagopa-node-forwarder_dev_secrets" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//key_vault_secrets_query?ref=v7.30.0"
+  source = "./.terraform/modules/__v3__/key_vault_secrets_query"
   providers = {
     azurerm = azurerm.dev
   }
@@ -13,7 +13,7 @@ module "pagopa-node-forwarder_dev_secrets" {
 }
 
 module "pagopa-debt-position_dev_secrets" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//key_vault_secrets_query?ref=v7.30.0"
+  source = "./.terraform/modules/__v3__/key_vault_secrets_query"
 
   providers = {
     azurerm = azurerm.dev

--- a/azure-devops/externals/00_secrets_prod.tf
+++ b/azure-devops/externals/00_secrets_prod.tf
@@ -4,7 +4,7 @@
 
 module "secrets" {
 
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//key_vault_secrets_query?ref=v7.30.0"
+  source = "./.terraform/modules/__v3__/key_vault_secrets_query"
 
 
   resource_group = local.prod_key_vault_resource_group
@@ -17,9 +17,6 @@ module "secrets" {
     "azure-devops-github-pr-TOKEN",
     "azure-devops-github-EMAIL",
     "azure-devops-github-USERNAME",
-    # "DEV-SUBSCRIPTION-ID",
-    # "UAT-SUBSCRIPTION-ID",
-    # "PROD-SUBSCRIPTION-ID",
     "ORG-SUBSCRIPTION-ID",
     "DEV-SIA-DOCKER-REGISTRY-PWD",
     "UAT-SIA-DOCKER-REGISTRY-PWD",

--- a/azure-devops/externals/00_secrets_uat.tf
+++ b/azure-devops/externals/00_secrets_uat.tf
@@ -1,5 +1,5 @@
 module "pagopa-node-forwarder_uat_secrets" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//key_vault_secrets_query?ref=v7.30.0"
+  source = "./.terraform/modules/__v3__/key_vault_secrets_query"
 
   providers = {
     azurerm = azurerm.uat
@@ -14,7 +14,7 @@ module "pagopa-node-forwarder_uat_secrets" {
 }
 
 module "pagopa-debt-position_uat_secrets" {
-  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git//key_vault_secrets_query?ref=v7.30.0"
+  source = "./.terraform/modules/__v3__/key_vault_secrets_query"
 
   providers = {
     azurerm = azurerm.uat

--- a/azure-devops/externals/03_service_connection_tls_certificate_legacy.tf
+++ b/azure-devops/externals/03_service_connection_tls_certificate_legacy.tf
@@ -4,7 +4,7 @@
 #tfsec:ignore:GEN003
 module "DEV-TLS-CERT-EXTERNALS-SERVICE-CONN" {
   depends_on = [data.azuredevops_project.project]
-  source     = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_serviceendpoint_azurerm_limited?ref=v5.5.0"
+  source     = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_serviceendpoint_azurerm_limited?ref=v9.2.1"
   providers = {
     azurerm = azurerm.dev
   }
@@ -44,7 +44,7 @@ resource "azurerm_key_vault_access_policy" "DEV-TLS-CERT-EXTERNALS-SERVICE-CONN_
 #tfsec:ignore:GEN003
 module "UAT-TLS-CERT-EXTERNALS-SERVICE-CONN" {
   depends_on = [data.azuredevops_project.project]
-  source     = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_serviceendpoint_azurerm_limited?ref=v5.5.0"
+  source     = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_serviceendpoint_azurerm_limited?ref=v9.2.1"
   providers = {
     azurerm = azurerm.uat
   }
@@ -83,7 +83,7 @@ resource "azurerm_key_vault_access_policy" "UAT-TLS-CERT-EXTERNALS-SERVICE-CONN_
 #tfsec:ignore:GEN003
 module "PROD-TLS-CERT-EXTERNALS-SERVICE-CONN" {
   depends_on = [data.azuredevops_project.project]
-  source     = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_serviceendpoint_azurerm_limited?ref=v5.5.0"
+  source     = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_serviceendpoint_azurerm_limited?ref=v9.2.1"
   providers = {
     azurerm = azurerm.prod
   }

--- a/azure-devops/externals/03_service_connections_tls_certificate.tf
+++ b/azure-devops/externals/03_service_connections_tls_certificate.tf
@@ -1,10 +1,10 @@
-##
-## ⛩ Service connection 2 🔐 KV@DEV 🟢
-##
-##tfsec:ignore:GEN003
-#module "DEV-EXTERNALS-TLS-CERT-SERVICE-CONN" {
+# #
+# # ⛩ Service connection 2 🔐 KV@DEV 🟢
+# #
+# #tfsec:ignore:GEN003
+# module "DEV-EXTERNALS-TLS-CERT-SERVICE-CONN" {
 #  depends_on = [data.azuredevops_project.project]
-#  source     = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_serviceendpoint_federated?ref=v5.5.0"
+#   source     = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_serviceendpoint_federated?ref=v9.2.1"
 #  providers = {
 #    azurerm = azurerm.dev
 #  }
@@ -19,15 +19,15 @@
 #  location            = var.location
 #  resource_group_name = local.dev_key_vault_resource_group
 #
-#}
+# }
 #
-#data "azurerm_key_vault" "kv_dev" {
+# data "azurerm_key_vault" "kv_dev" {
 #  provider            = azurerm.dev
 #  name                = local.dev_key_vault_name
 #  resource_group_name = local.dev_key_vault_resource_group
-#}
+# }
 #
-#resource "azurerm_key_vault_access_policy" "DEV-EXTERNALS-TLS-CERT-SERVICE-CONN_kv_dev" {
+# resource "azurerm_key_vault_access_policy" "DEV-EXTERNALS-TLS-CERT-SERVICE-CONN_kv_dev" {
 #  provider = azurerm.dev
 #
 #  key_vault_id = data.azurerm_key_vault.kv_dev.id
@@ -35,15 +35,15 @@
 #  object_id    = module.DEV-EXTERNALS-TLS-CERT-SERVICE-CONN.service_principal_object_id
 #
 #  certificate_permissions = ["Get", "Import"]
-#}
+# }
 #
-##
-## ⛩ Service connection 2 🔐 KV@UAT 🟨
-##
-##tfsec:ignore:GEN003
-#module "UAT-EXTERNALS-TLS-CERT-SERVICE-CONN" {
+# #
+# # ⛩ Service connection 2 🔐 KV@UAT 🟨
+# #
+# #tfsec:ignore:GEN003
+# module "UAT-EXTERNALS-TLS-CERT-SERVICE-CONN" {
 #  depends_on = [data.azuredevops_project.project]
-#  source     = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_serviceendpoint_federated?ref=v5.5.0"
+#   source     = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_serviceendpoint_federated?ref=v9.2.1"
 #  providers = {
 #    azurerm = azurerm.uat
 #  }
@@ -58,30 +58,30 @@
 #
 #  location            = var.location
 #  resource_group_name = local.uat_key_vault_resource_group
-#}
+# }
 #
-#data "azurerm_key_vault" "kv_uat" {
+# data "azurerm_key_vault" "kv_uat" {
 #  provider            = azurerm.uat
 #  name                = local.uat_key_vault_name
 #  resource_group_name = local.uat_key_vault_resource_group
-#}
+# }
 #
-#resource "azurerm_key_vault_access_policy" "UAT-EXTERNALS-TLS-CERT-SERVICE-CONN_kv_uat" {
+# resource "azurerm_key_vault_access_policy" "UAT-EXTERNALS-TLS-CERT-SERVICE-CONN_kv_uat" {
 #  provider     = azurerm.uat
 #  key_vault_id = data.azurerm_key_vault.kv_uat.id
 #  tenant_id    = data.azurerm_client_config.current.tenant_id
 #  object_id    = module.UAT-EXTERNALS-TLS-CERT-SERVICE-CONN.service_principal_object_id
 #
 #  certificate_permissions = ["Get", "Import"]
-#}
+# }
 #
-##
-## ⛩ Service connection 2 🔐 KV@PROD 🛑
-##
-##tfsec:ignore:GEN003
-#module "PROD-EXTERNALS-TLS-CERT-SERVICE-CONN" {
+# #
+# # ⛩ Service connection 2 🔐 KV@PROD 🛑
+# #
+# #tfsec:ignore:GEN003
+# module "PROD-EXTERNALS-TLS-CERT-SERVICE-CONN" {
 #  depends_on = [data.azuredevops_project.project]
-#  source     = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_serviceendpoint_federated?ref=v5.5.0"
+#   source     = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_serviceendpoint_federated?ref=v9.2.1"
 #  providers = {
 #    azurerm = azurerm.prod
 #  }
@@ -95,19 +95,19 @@
 #
 #  location            = var.location
 #  resource_group_name = local.prod_key_vault_resource_group
-#}
+# }
 #
-#data "azurerm_key_vault" "kv_prod" {
+# data "azurerm_key_vault" "kv_prod" {
 #  provider            = azurerm.prod
 #  name                = local.prod_key_vault_name
 #  resource_group_name = local.prod_key_vault_resource_group
-#}
+# }
 #
-#resource "azurerm_key_vault_access_policy" "PROD-EXTERNALS-TLS-CERT-SERVICE-CONN_kv_prod" {
+# resource "azurerm_key_vault_access_policy" "PROD-EXTERNALS-TLS-CERT-SERVICE-CONN_kv_prod" {
 #  provider     = azurerm.prod
 #  key_vault_id = data.azurerm_key_vault.kv_prod.id
 #  tenant_id    = data.azurerm_client_config.current.tenant_id
 #  object_id    = module.PROD-EXTERNALS-TLS-CERT-SERVICE-CONN.service_principal_object_id
 #
 #  certificate_permissions = ["Get", "Import"]
-#}
+# }

--- a/azure-devops/externals/03_service_connections_tls_certificate.tf
+++ b/azure-devops/externals/03_service_connections_tls_certificate.tf
@@ -1,113 +1,119 @@
-# #
-# # ⛩ Service connection 2 🔐 KV@DEV 🟢
-# #
-# #tfsec:ignore:GEN003
-# module "DEV-EXTERNALS-TLS-CERT-SERVICE-CONN" {
-#  depends_on = [data.azuredevops_project.project]
-#   source     = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_serviceendpoint_federated?ref=v9.2.1"
-#  providers = {
-#    azurerm = azurerm.dev
-#  }
 #
-#  project_id = data.azuredevops_project.project.id
-#  #tfsec:ignore:general-secrets-no-plaintext-exposure
-#  name              = "${local.prefix}-${local.domain}-d-azdo-EXTERNALS-TLS-CERT-kv-policy"
-#  tenant_id         = data.azurerm_client_config.current.tenant_id
-#  subscription_id   = data.azurerm_subscriptions.dev.subscriptions[0].subscription_id
-#  subscription_name = var.dev_subscription_name
+# ⛩ Service connection 2 🔐 KV@DEV 🟢
 #
-#  location            = var.location
-#  resource_group_name = local.dev_key_vault_resource_group
+#tfsec:ignore:GEN003
+module "DEV-EXTERNALS-TLS-CERT-SERVICE-CONN-FEDERATED" {
+ depends_on = [data.azuredevops_project.project]
+  # source     = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_serviceendpoint_federated?ref=v9.2.1"
+  source = "./.terraform/modules/__azdo__/azuredevops_serviceendpoint_federated"
+
+ providers = {
+   azurerm = azurerm.dev
+ }
+
+ project_id = data.azuredevops_project.project.id
+ #tfsec:ignore:general-secrets-no-plaintext-exposure
+ name              = "${local.prefix}-${local.domain}-d-azdo-EXTERNALS-TLS-CERT-kv-policy"
+ tenant_id         = data.azurerm_client_config.current.tenant_id
+ subscription_id   = data.azurerm_subscriptions.dev.subscriptions[0].subscription_id
+ subscription_name = var.dev_subscription_name
+
+ location            = var.location
+ resource_group_name = local.dev_key_vault_resource_group
+
+}
+
+data "azurerm_key_vault" "kv_dev" {
+ provider            = azurerm.dev
+ name                = local.dev_key_vault_name
+ resource_group_name = local.dev_key_vault_resource_group
+}
+
+resource "azurerm_key_vault_access_policy" "DEV-EXTERNALS-TLS-CERT-SERVICE-CONN-FEDERATED_kv_dev" {
+ provider = azurerm.dev
+
+ key_vault_id = data.azurerm_key_vault.kv_dev.id
+ tenant_id    = data.azurerm_client_config.current.tenant_id
+ object_id    = module.DEV-EXTERNALS-TLS-CERT-SERVICE-CONN-FEDERATED.service_principal_object_id
+
+ certificate_permissions = ["Get", "Import"]
+}
+
 #
-# }
+# ⛩ Service connection 2 🔐 KV@UAT 🟨
 #
-# data "azurerm_key_vault" "kv_dev" {
-#  provider            = azurerm.dev
-#  name                = local.dev_key_vault_name
-#  resource_group_name = local.dev_key_vault_resource_group
-# }
+#tfsec:ignore:GEN003
+module "UAT-EXTERNALS-TLS-CERT-SERVICE-CONN-FEDERATED" {
+ depends_on = [data.azuredevops_project.project]
+  # source     = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_serviceendpoint_federated?ref=v9.2.1"
+    source = "./.terraform/modules/__azdo__/azuredevops_serviceendpoint_federated"
+
+ providers = {
+   azurerm = azurerm.uat
+ }
+
+ project_id = data.azuredevops_project.project.id
+ #tfsec:ignore:general-secrets-no-plaintext-exposure
+ name              = "${local.prefix}-${local.domain}-u-azdo-EXTERNALS-TLS-CERT-kv-policy"
+ tenant_id         = data.azurerm_client_config.current.tenant_id
+ subscription_id   = data.azurerm_subscriptions.uat.subscriptions[0].subscription_id
+ subscription_name = var.uat_subscription_name
+
+
+ location            = var.location
+ resource_group_name = local.uat_key_vault_resource_group
+}
+
+data "azurerm_key_vault" "kv_uat" {
+ provider            = azurerm.uat
+ name                = local.uat_key_vault_name
+ resource_group_name = local.uat_key_vault_resource_group
+}
+
+resource "azurerm_key_vault_access_policy" "UAT-EXTERNALS-TLS-CERT-SERVICE-CONN-FEDERATED_kv_uat" {
+ provider     = azurerm.uat
+ key_vault_id = data.azurerm_key_vault.kv_uat.id
+ tenant_id    = data.azurerm_client_config.current.tenant_id
+ object_id    = module.UAT-EXTERNALS-TLS-CERT-SERVICE-CONN-FEDERATED.service_principal_object_id
+
+ certificate_permissions = ["Get", "Import"]
+}
+
 #
-# resource "azurerm_key_vault_access_policy" "DEV-EXTERNALS-TLS-CERT-SERVICE-CONN_kv_dev" {
-#  provider = azurerm.dev
+# ⛩ Service connection 2 🔐 KV@PROD 🛑
 #
-#  key_vault_id = data.azurerm_key_vault.kv_dev.id
-#  tenant_id    = data.azurerm_client_config.current.tenant_id
-#  object_id    = module.DEV-EXTERNALS-TLS-CERT-SERVICE-CONN.service_principal_object_id
-#
-#  certificate_permissions = ["Get", "Import"]
-# }
-#
-# #
-# # ⛩ Service connection 2 🔐 KV@UAT 🟨
-# #
-# #tfsec:ignore:GEN003
-# module "UAT-EXTERNALS-TLS-CERT-SERVICE-CONN" {
-#  depends_on = [data.azuredevops_project.project]
-#   source     = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_serviceendpoint_federated?ref=v9.2.1"
-#  providers = {
-#    azurerm = azurerm.uat
-#  }
-#
-#  project_id = data.azuredevops_project.project.id
-#  #tfsec:ignore:general-secrets-no-plaintext-exposure
-#  name              = "${local.prefix}-${local.domain}-u-azdo-EXTERNALS-TLS-CERT-kv-policy"
-#  tenant_id         = data.azurerm_client_config.current.tenant_id
-#  subscription_id   = data.azurerm_subscriptions.uat.subscriptions[0].subscription_id
-#  subscription_name = var.uat_subscription_name
-#
-#
-#  location            = var.location
-#  resource_group_name = local.uat_key_vault_resource_group
-# }
-#
-# data "azurerm_key_vault" "kv_uat" {
-#  provider            = azurerm.uat
-#  name                = local.uat_key_vault_name
-#  resource_group_name = local.uat_key_vault_resource_group
-# }
-#
-# resource "azurerm_key_vault_access_policy" "UAT-EXTERNALS-TLS-CERT-SERVICE-CONN_kv_uat" {
-#  provider     = azurerm.uat
-#  key_vault_id = data.azurerm_key_vault.kv_uat.id
-#  tenant_id    = data.azurerm_client_config.current.tenant_id
-#  object_id    = module.UAT-EXTERNALS-TLS-CERT-SERVICE-CONN.service_principal_object_id
-#
-#  certificate_permissions = ["Get", "Import"]
-# }
-#
-# #
-# # ⛩ Service connection 2 🔐 KV@PROD 🛑
-# #
-# #tfsec:ignore:GEN003
-# module "PROD-EXTERNALS-TLS-CERT-SERVICE-CONN" {
-#  depends_on = [data.azuredevops_project.project]
-#   source     = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_serviceendpoint_federated?ref=v9.2.1"
-#  providers = {
-#    azurerm = azurerm.prod
-#  }
-#
-#  project_id = data.azuredevops_project.project.id
-#  #tfsec:ignore:general-secrets-no-plaintext-exposure
-#  name              = "${local.prefix}-${local.domain}-p-azdo-EXTERNALS-TLS-CERT-kv-policy"
-#  tenant_id         = data.azurerm_client_config.current.tenant_id
-#  subscription_id   = data.azurerm_subscriptions.prod.subscriptions[0].subscription_id
-#  subscription_name = var.prod_subscription_name
-#
-#  location            = var.location
-#  resource_group_name = local.prod_key_vault_resource_group
-# }
-#
-# data "azurerm_key_vault" "kv_prod" {
-#  provider            = azurerm.prod
-#  name                = local.prod_key_vault_name
-#  resource_group_name = local.prod_key_vault_resource_group
-# }
-#
-# resource "azurerm_key_vault_access_policy" "PROD-EXTERNALS-TLS-CERT-SERVICE-CONN_kv_prod" {
-#  provider     = azurerm.prod
-#  key_vault_id = data.azurerm_key_vault.kv_prod.id
-#  tenant_id    = data.azurerm_client_config.current.tenant_id
-#  object_id    = module.PROD-EXTERNALS-TLS-CERT-SERVICE-CONN.service_principal_object_id
-#
-#  certificate_permissions = ["Get", "Import"]
-# }
+#tfsec:ignore:GEN003
+module "PROD-EXTERNALS-TLS-CERT-SERVICE-CONN-FEDERATED" {
+ depends_on = [data.azuredevops_project.project]
+  # source     = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_serviceendpoint_federated?ref=v9.2.1"
+    source = "./.terraform/modules/__azdo__/azuredevops_serviceendpoint_federated"
+
+ providers = {
+   azurerm = azurerm.prod
+ }
+
+ project_id = data.azuredevops_project.project.id
+ #tfsec:ignore:general-secrets-no-plaintext-exposure
+ name              = "${local.prefix}-${local.domain}-p-azdo-EXTERNALS-TLS-CERT-kv-policy"
+ tenant_id         = data.azurerm_client_config.current.tenant_id
+ subscription_id   = data.azurerm_subscriptions.prod.subscriptions[0].subscription_id
+ subscription_name = var.prod_subscription_name
+
+ location            = var.location
+ resource_group_name = local.prod_key_vault_resource_group
+}
+
+data "azurerm_key_vault" "kv_prod" {
+ provider            = azurerm.prod
+ name                = local.prod_key_vault_name
+ resource_group_name = local.prod_key_vault_resource_group
+}
+
+resource "azurerm_key_vault_access_policy" "PROD-EXTERNALS-TLS-CERT-SERVICE-CONN-FEDERATED_kv_prod" {
+ provider     = azurerm.prod
+ key_vault_id = data.azurerm_key_vault.kv_prod.id
+ tenant_id    = data.azurerm_client_config.current.tenant_id
+ object_id    = module.PROD-EXTERNALS-TLS-CERT-SERVICE-CONN-FEDERATED.service_principal_object_id
+
+ certificate_permissions = ["Get", "Import"]
+}

--- a/azure-devops/externals/05_tlscert-prod-wfesp-dr-gov-pagopa-it.tf
+++ b/azure-devops/externals/05_tlscert-prod-wfesp-dr-gov-pagopa-it.tf
@@ -42,7 +42,7 @@ module "tlscert-prod-wfesp-dr-pagopa-gov-it-cert_az" {
     azurerm = azurerm.prod
   }
 
-  source = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_build_definition_tls_cert_federated?ref=v5.5.0"
+  source = "./.terraform/modules/__azdo__/azuredevops_build_definition_tls_cert_federated"
   count  = var.tlscert-prod-wfesp-dr-pagopa-gov-it.pipeline.enable_tls_cert == true ? 1 : 0
 
   project_id                   = data.azuredevops_project.project.id

--- a/azure-devops/externals/05_tlscert-prod-wfesp-gov-pagopa-it.tf
+++ b/azure-devops/externals/05_tlscert-prod-wfesp-gov-pagopa-it.tf
@@ -42,7 +42,7 @@ module "tlscert-prod-wfesp-pagopa-gov-it-cert_az" {
     azurerm = azurerm.prod
   }
 
-  source = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_build_definition_tls_cert_federated?ref=v5.5.0"
+  source = "./.terraform/modules/__azdo__/azuredevops_build_definition_tls_cert_federated"
   count  = var.tlscert-prod-wfesp-pagopa-gov-it.pipeline.enable_tls_cert == true ? 1 : 0
 
   project_id                   = data.azuredevops_project.project.id

--- a/azure-devops/externals/05_tlscert-prod-wisp2-gov-pagopa-it.tf
+++ b/azure-devops/externals/05_tlscert-prod-wisp2-gov-pagopa-it.tf
@@ -42,7 +42,7 @@ module "tlscert-prod-wisp2-pagopa-gov-it-cert_az" {
     azurerm = azurerm.prod
   }
 
-  source = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_build_definition_tls_cert_federated?ref=v5.5.0"
+  source = "./.terraform/modules/__azdo__/azuredevops_build_definition_tls_cert_federated"
   count  = var.tlscert-prod-wisp2-pagopa-gov-it.pipeline.enable_tls_cert == true ? 1 : 0
 
   project_id                   = data.azuredevops_project.project.id

--- a/azure-devops/externals/05_tlscert-uat-uat-wisp2-gov-pagopa-it.tf
+++ b/azure-devops/externals/05_tlscert-uat-uat-wisp2-gov-pagopa-it.tf
@@ -43,7 +43,7 @@ module "tlscert-uat-uat-wisp2-gov-pagopa-it-cert_az" {
     azurerm = azurerm.uat
   }
 
-  source = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_build_definition_tls_cert_federated?ref=v5.5.0"
+  source = "./.terraform/modules/__azdo__/azuredevops_build_definition_tls_cert_federated"
   count  = var.tlscert-uat-uat-wisp2-gov-pagopa-it.pipeline.enable_tls_cert == true ? 1 : 0
 
   project_id                   = data.azuredevops_project.project.id

--- a/azure-devops/externals/05_tlscert-uat-wfesp-test-gov-pagopa-it.tf
+++ b/azure-devops/externals/05_tlscert-uat-wfesp-test-gov-pagopa-it.tf
@@ -43,7 +43,7 @@ module "tlscert-uat-wfesp-test-gov-pagopa-it-cert_az" {
     azurerm = azurerm.uat
   }
 
-  source = "git::https://github.com/pagopa/azuredevops-tf-modules.git//azuredevops_build_definition_tls_cert_federated?ref=v5.5.0"
+  source = "./.terraform/modules/__azdo__/azuredevops_build_definition_tls_cert_federated"
   count  = var.tlscert-uat-wfesp-test-gov-pagopa-it.pipeline.enable_tls_cert == true ? 1 : 0
 
   project_id                   = data.azuredevops_project.project.id

--- a/azure-devops/externals/99_main.tf
+++ b/azure-devops/externals/99_main.tf
@@ -1,12 +1,25 @@
 terraform {
-  required_version = ">= 1.3.5"
+  required_version = ">= 1.9.5"
   required_providers {
     azuredevops = {
       source  = "microsoft/azuredevops"
-      version = "<= 0.11.0"
+      version = "~> 1.1"
     }
     azurerm = {
-      version = "<= 3.85.0"
+      source = "hashicorp/azurerm"
+      version = "~> 3.101"
+    }
+    azuread = {
+      source = "hashicorp/azuread"
+      version = "~> 2.50"
+    }
+    null = {
+      source = "hashicorp/null"
+      version = "~> 3.2"
+    }
+    time = {
+      source = "hashicorp/time"
+      version = "~> 0.10"
     }
   }
   backend "azurerm" {}
@@ -44,4 +57,14 @@ provider "azurerm" {
   }
   alias           = "prod"
   subscription_id = data.azurerm_subscriptions.prod.subscriptions[0].subscription_id
+}
+
+module "__v3__" {
+  # https://github.com/pagopa/terraform-azurerm-v3/releases/tag/v8.83.1
+  source = "git::https://github.com/pagopa/terraform-azurerm-v3.git?ref=087a57940a67444c3b883030c54ceb78562c64ef"
+}
+
+module "__azdo__" {
+  # https://github.com/pagopa/azuredevops-tf-modules/releases/tag/v9.2.1
+  source = "git::https://github.com/pagopa/azuredevops-tf-modules.git?ref=7e23d73d22e7b37352c25a32cc40f6f42b6569ea"
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

- created managed identities for externals tls certs
- removed old certificates
- updated module and providers

### Motivation and context

The service connection expires because it use legacy service principal, now we changed to managed identity to avoid this kind of problems

### Type of changes

- [x] Add new pipeline
- [x] Update pipeline configuration
- [x] Remove pipeline

### :warning: If it's new pipeline with code review have you added pagopa-github-bot -> Role: admin?

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
