### PR TITLE
chore: enable deploy of one identity mock to UAT env for soak tests

### DIFF
--- a/azure-devops/checkout/06_pagopa-checkout-identity-provider-mock.tf
+++ b/azure-devops/checkout/06_pagopa-checkout-identity-provider-mock.tf
@@ -40,10 +40,15 @@ locals {
     dev_container_registry_service_conn = data.azuredevops_serviceendpoint_azurecr.dev_weu_workload_identity.id
     dev_container_registry_name         = data.azuredevops_serviceendpoint_azurecr.dev_weu_workload_identity.service_endpoint_name
 
+    uat_container_registry_service_conn = data.azuredevops_serviceendpoint_azurecr.uat_weu_workload_identity.id
+    uat_container_registry_name         = data.azuredevops_serviceendpoint_azurecr.uat_weu_workload_identity.service_endpoint_name
+
     # aks section
     dev_kubernetes_service_conn = azuredevops_serviceendpoint_kubernetes.aks_dev.id
+    uat_kubernetes_service_conn = azuredevops_serviceendpoint_kubernetes.aks_uat.id
 
     dev_container_namespace = "pagopadcommonacr.azurecr.io"
+    uat_container_namespace = "pagopaucommonacr.azurecr.io"
   }
   # deploy secrets
   pagopa-checkout-identity-provider-mock-variables_secret_deploy = {
@@ -76,5 +81,7 @@ module "pagopa-checkout-identity-provider-mock_deploy" {
     data.azuredevops_serviceendpoint_github.github_ro.id,
     data.azuredevops_serviceendpoint_azurecr.dev_weu_workload_identity.id,
     data.azuredevops_serviceendpoint_azurerm.dev.id,
+    data.azuredevops_serviceendpoint_azurecr.uat_weu_workload_identity.id,
+    data.azuredevops_serviceendpoint_azurerm.uat.id,
   ]
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Add secrets and variables for UAT deploy of checkout identity provider mock.
This will be used for soak tests
<!--- Describe your changes in detail -->

### Motivation and context
Add secrets and variables for UAT deploy of checkout identity provider mock.
This will be used for soak tests

<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new pipeline
- [x] Update pipeline configuration
- [ ] Remove pipeline

### :warning: If it's new pipeline with code review have you added pagopa-github-bot -> Role: admin?

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
