### PR TITLE
fix(wallet fe deploy): [CHK-3753] user wallet token for E2E tests

### DIFF
--- a/azure-devops/pay-wallet/06_pagopa-payment-wallet-fe.tf
+++ b/azure-devops/pay-wallet/06_pagopa-payment-wallet-fe.tf
@@ -58,6 +58,8 @@ locals {
   pagopa-payment-wallet-fe-variables_secret_deploy = {
     git_mail     = module.secrets.values["azure-devops-github-EMAIL"].value
     git_username = module.secrets.values["azure-devops-github-USERNAME"].value
+    user_wallet_token_dev = module.wallet_dev_secrets.values["wallet-token-test-key"].value
+    user_wallet_token_uat = module.wallet_uat_secrets.values["wallet-token-test-key"].value
   }
 }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Add user wallet token used for E2E tests
<!--- Describe your changes in detail -->

### Motivation and context
This token is used during E2E tests to perform start session api call
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new pipeline
- [x] Update pipeline configuration
- [ ] Remove pipeline

### :warning: If it's new pipeline with code review have you added pagopa-github-bot -> Role: admin?

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
