### PR TITLE
fix: set kv ref for checkout domain

### DIFF
--- a/azure-devops/iac/00_secrets_kv.tf
+++ b/azure-devops/iac/00_secrets_kv.tf
@@ -35,9 +35,9 @@ module "uat_secrets" {
 
 
   secrets = [
-    "pagopa-d-weu-uat-aks-azure-devops-sa-token",
-    "pagopa-d-weu-uat-aks-azure-devops-sa-cacrt",
-    "pagopa-d-weu-uat-aks-apiserver-url"
+    "pagopa-u-weu-uat-aks-azure-devops-sa-token",
+    "pagopa-u-weu-uat-aks-azure-devops-sa-cacrt",
+    "pagopa-u-weu-uat-aks-apiserver-url"
   ]
 }
 
@@ -56,7 +56,7 @@ module "prod_secrets" {
 
   secrets = [
     "pagopa-p-weu-prod-aks-azure-devops-sa-token",
-    "pagopa-d-weu-prod-aks-azure-devops-sa-cacrt",
-    "pagopa-d-weu-prod-aks-apiserver-url"
+    "pagopa-p-weu-prod-aks-azure-devops-sa-cacrt",
+    "pagopa-p-weu-prod-aks-apiserver-url"
   ]
 }

--- a/azure-devops/iac/99_locals.tf
+++ b/azure-devops/iac/99_locals.tf
@@ -16,8 +16,8 @@ locals {
     {
       name : "checkout",
       envs : ["d", "u", "p"],
-      kv_name : "",
-      rg_name : "",
+      kv_name : "pagopa-%s-checkout-kv",
+      rg_name : "pagopa-%s-checkout-sec-rg",
       code_review : true,
       deploy : true,
       pipeline_prefix : "checkout",


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Set checkout kv ref in order to make iac variables being populated correctly with AKS refs
<!--- Describe your changes in detail -->

### Motivation and context
Set checkout kv ref in order to make iac variables being populated correctly with AKS refs
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new pipeline
- [x] Update pipeline configuration
- [ ] Remove pipeline

### :warning: If it's new pipeline with code review have you added pagopa-github-bot -> Role: admin?

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
