### PR TITLE
fix: [CHK-4128] differentiate deploy pipeline names

### DIFF
--- a/azure-devops/ecommerce/06_pagopa-ecommerce-jwt-issuer-service.tf
+++ b/azure-devops/ecommerce/06_pagopa-ecommerce-jwt-issuer-service.tf
@@ -27,8 +27,7 @@ locals {
   }
 
   pagopa-jwt-issuer-service-deploy-repository-conf = {
-    yml_prefix_name      = "ecommerce",
-    pipeline_name_prefix = "pagopa-ecommerce-jwt-issuer-service"
+    yml_prefix_name = "ecommerce"
   }
 
   # global vars
@@ -119,6 +118,7 @@ module "pagopa-jwt-issuer-service_deploy" {
     var.pagopa-jwt-issuer-service.repository,
     local.pagopa-jwt-issuer-service-deploy-repository-conf
   )
+  pipeline_name_prefix         = "pagopa-ecommerce-jwt-issuer-service"
   github_service_connection_id = data.azuredevops_serviceendpoint_github.github_rw.service_endpoint_id
 
   path = "${local.domain}\\pagopa-jwt-issuer-service"

--- a/azure-devops/ecommerce/06_pagopa-ecommerce-jwt-issuer-service.tf
+++ b/azure-devops/ecommerce/06_pagopa-ecommerce-jwt-issuer-service.tf
@@ -27,7 +27,8 @@ locals {
   }
 
   pagopa-jwt-issuer-service-deploy-repository-conf = {
-    yml_prefix_name = "ecommerce"
+    yml_prefix_name      = "ecommerce",
+    pipeline_name_prefix = "pagopa-ecommerce-jwt-issuer-service"
   }
 
   # global vars

--- a/azure-devops/nodo/06_pagopa-nodo-service.tf
+++ b/azure-devops/nodo/06_pagopa-nodo-service.tf
@@ -91,8 +91,8 @@ locals {
     uat_container_namespace  = "pagopaucommonacr.azurecr.io"
     prod_container_namespace = "pagopapcommonacr.azurecr.io"
 
-    azure_insights_enabled_dev = true
-    azure_insights_enabled_uat = true
+    azure_insights_enabled_dev  = true
+    azure_insights_enabled_uat  = true
     azure_insights_enabled_prod = true
 
     TF_APPINSIGHTS_SERVICE_CONN_DEV = module.DEV-APPINSIGHTS-SERVICE-CONN.service_endpoint_name

--- a/azure-devops/pay-wallet/06_pagopa-payment-wallet-jwt-issuer-service.tf
+++ b/azure-devops/pay-wallet/06_pagopa-payment-wallet-jwt-issuer-service.tf
@@ -16,8 +16,7 @@ variable "pagopa-jwt-issuer-service" {
 locals {
 
   pagopa-jwt-issuer-service-deploy-repository-conf = {
-    yml_prefix_name      = "pay-wallet",
-    pipeline_name_prefix = "pagopa-pay-wallet-jwt-issuer-service"
+    yml_prefix_name = "pay-wallet"
   }
 
   # global vars
@@ -69,6 +68,7 @@ module "pagopa-jwt-issuer-service_deploy" {
     var.pagopa-jwt-issuer-service.repository,
     local.pagopa-jwt-issuer-service-deploy-repository-conf
   )
+  pipeline_name_prefix         = "pagopa-pay-wallet-jwt-issuer-service"
   github_service_connection_id = data.azuredevops_serviceendpoint_github.github_rw.service_endpoint_id
   path                         = "${local.domain}\\pagopa-jwt-issuer-service"
 

--- a/azure-devops/pay-wallet/06_pagopa-payment-wallet-jwt-issuer-service.tf
+++ b/azure-devops/pay-wallet/06_pagopa-payment-wallet-jwt-issuer-service.tf
@@ -5,7 +5,6 @@ variable "pagopa-jwt-issuer-service" {
       name           = "pagopa-jwt-issuer-service" #repo template that contains code to be deployed to both payment wallet and ecommerce domains
       branch_name    = "refs/heads/main"
       pipelines_path = ".devops"
-
     }
     pipeline = {
       enable_deploy = true
@@ -17,7 +16,8 @@ variable "pagopa-jwt-issuer-service" {
 locals {
 
   pagopa-jwt-issuer-service-deploy-repository-conf = {
-    yml_prefix_name = "pay-wallet"
+    yml_prefix_name      = "pay-wallet",
+    pipeline_name_prefix = "pagopa-pay-wallet-jwt-issuer-service"
   }
 
   # global vars


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Differentiate jwt token issuer deploy pipeline names
<!--- Describe your changes in detail -->

### Motivation and context
This modification is needed since azure devops gha use pipeline name for pipeline triggering, failing if there is more than one pipeline with the same name
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new pipeline
- [x] Update pipeline configuration
- [ ] Remove pipeline

### :warning: If it's new pipeline with code review have you added pagopa-github-bot -> Role: admin?

- [ ] Yes
- [x] No

### Other information
![Screenshot 2025-05-13 alle 10 28 33](https://github.com/user-attachments/assets/3388bc90-ae17-451e-bf90-b57e9a2c9499)

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
