### PR TITLE
feat(ecommerce-event-dispatcher): add mongo and queue secrets in deploy

### DIFF
--- a/azure-devops/ecommerce/00_secrets_ecommerce.tf
+++ b/azure-devops/ecommerce/00_secrets_ecommerce.tf
@@ -28,6 +28,8 @@ module "ecommerce_dev_secrets" {
     "helpdesk-service-testing-email-history",
     "ecommerce-jwt-issuer-service-primary-api-key",
     "ecommerce-jwt-issuer-service-secondary-api-key",
+    "mongo-ecommerce-password",
+    "ecommerce-storage-transient-connection-string"
   ]
 }
 
@@ -56,6 +58,8 @@ module "ecommerce_uat_secrets" {
     "helpdesk-ecommerce-commands-testing-api-key",
     "ecommerce-jwt-issuer-service-primary-api-key",
     "ecommerce-jwt-issuer-service-secondary-api-key",
+    "mongo-ecommerce-password",
+    "ecommerce-storage-transient-connection-string"
   ]
 }
 

--- a/azure-devops/ecommerce/06_pagopa-ecommerce-event-dispatcher-service.tf
+++ b/azure-devops/ecommerce/06_pagopa-ecommerce-event-dispatcher-service.tf
@@ -70,10 +70,14 @@ locals {
 
   # deploy secrets
   pagopa-ecommerce-event-dispatcher-service-variables_secret_deploy = {
-    git_mail             = module.secrets.values["azure-devops-github-EMAIL"].value
-    git_username         = module.secrets.values["azure-devops-github-USERNAME"].value
-    tenant_id            = data.azurerm_client_config.current.tenant_id
-    prod_service_api_key = var.pagopa-ecommerce-event-dispatcher-service.use_primary_api_key ? module.ecommerce_prod_secrets.values["ecommerce-event-dispatcher-service-primary-api-key"].value : module.ecommerce_prod_secrets.values["ecommerce-event-dispatcher-service-secondary-api-key"].value
+    git_mail                                = module.secrets.values["azure-devops-github-EMAIL"].value
+    git_username                            = module.secrets.values["azure-devops-github-USERNAME"].value
+    tenant_id                               = data.azurerm_client_config.current.tenant_id
+    prod_service_api_key                    = var.pagopa-ecommerce-event-dispatcher-service.use_primary_api_key ? module.ecommerce_prod_secrets.values["ecommerce-event-dispatcher-service-primary-api-key"].value : module.ecommerce_prod_secrets.values["ecommerce-event-dispatcher-service-secondary-api-key"].value
+    dev_mongo_ecommerce_password            = module.ecommerce_dev_secrets.values["mongo-ecommerce-password"].value
+    uat_mongo_ecommerce_password            = module.ecommerce_uat_secrets.values["mongo-ecommerce-password"].value
+    dev_transient_storage_connection_string = module.ecommerce_dev_secrets.values["ecommerce-storage-transient-connection-string"].value
+    uat_transient_storage_connection_string = module.ecommerce_uat_secrets.values["ecommerce-storage-transient-connection-string"].value
   }
 }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes
Add for ecommerce-event-dispatcher service DEV and UAT secrets that will hold mongo DB password and transient storage queue connection strings
<!--- Describe your changes in detail -->

### Motivation and context
Those secrets will be used by integration tests to write/read events from MongoDB and to write events to transient queues  in order to trigger tests
<!--- Why is this change required? What problem does it solve? -->

### Type of changes

- [ ] Add new pipeline
- [x] Update pipeline configuration
- [ ] Remove pipeline

### :warning: If it's new pipeline with code review have you added pagopa-github-bot -> Role: admin?

- [ ] Yes
- [x] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
