### PR TITLE
feat(commons): [CHK-4391] add github ro token to commons dependent pipelines

### DIFF
--- a/azure-devops/ecommerce/00_secrets_ecommerce.tf
+++ b/azure-devops/ecommerce/00_secrets_ecommerce.tf
@@ -80,6 +80,7 @@ module "ecommerce_prod_secrets" {
     "pagopa-p-weu-prod-aks-apiserver-url",
     "touchpoint-mail",
     "ecommerce-event-dispatcher-service-primary-api-key",
-    "ecommerce-event-dispatcher-service-secondary-api-key"
+    "ecommerce-event-dispatcher-service-secondary-api-key",
+    "ecommerce-github-packages-read-bot-token"
   ]
 }

--- a/azure-devops/ecommerce/06_pagopa-ecommerce-cdc-service.tf
+++ b/azure-devops/ecommerce/06_pagopa-ecommerce-cdc-service.tf
@@ -40,7 +40,7 @@ locals {
   }
   # code_review secrets
   pagopa-ecommerce-cdc-service-variables_secret_code_review = {
-    github_ro_token = module.secrets.values[local.github_pkg_ro_token_name].value
+    github_ro_token = module.ecommerce_prod_secrets.values["ecommerce-github-packages-read-bot-token"].value
   }
   # deploy vars
   pagopa-ecommerce-cdc-service-variables_deploy = {
@@ -70,7 +70,7 @@ locals {
     git_mail        = module.secrets.values["azure-devops-github-EMAIL"].value
     git_username    = module.secrets.values["azure-devops-github-USERNAME"].value
     tenant_id       = data.azurerm_client_config.current.tenant_id
-    github_ro_token = module.secrets.values[local.github_pkg_ro_token_name].value
+    github_ro_token = module.ecommerce_prod_secrets.values["ecommerce-github-packages-read-bot-token"].value
   }
 }
 

--- a/azure-devops/ecommerce/06_pagopa-ecommerce-event-dispatcher-service.tf
+++ b/azure-devops/ecommerce/06_pagopa-ecommerce-event-dispatcher-service.tf
@@ -42,7 +42,7 @@ locals {
   }
   # code_review secrets
   pagopa-ecommerce-event-dispatcher-service-variables_secret_code_review = {
-    github_ro_token = module.secrets.values[local.github_pkg_ro_token_name].value
+    github_ro_token = module.ecommerce_prod_secrets.values["ecommerce-github-packages-read-bot-token"].value
   }
   # deploy vars
   pagopa-ecommerce-event-dispatcher-service-variables_deploy = {
@@ -78,7 +78,7 @@ locals {
     uat_mongo_ecommerce_password            = module.ecommerce_uat_secrets.values["mongo-ecommerce-password"].value
     dev_transient_storage_connection_string = module.ecommerce_dev_secrets.values["ecommerce-storage-transient-connection-string"].value
     uat_transient_storage_connection_string = module.ecommerce_uat_secrets.values["ecommerce-storage-transient-connection-string"].value
-    github_ro_token = module.secrets.values[local.github_pkg_ro_token_name].value
+    github_ro_token                         = module.ecommerce_prod_secrets.values["ecommerce-github-packages-read-bot-token"].value
   }
 }
 

--- a/azure-devops/ecommerce/06_pagopa-ecommerce-helpdesk-commands-service.tf
+++ b/azure-devops/ecommerce/06_pagopa-ecommerce-helpdesk-commands-service.tf
@@ -41,7 +41,7 @@ locals {
   }
   # code_review secrets
   pagopa-ecommerce-helpdesk-commands-service-variables_secret_code_review = {
-    github_ro_token = module.secrets.values[local.github_pkg_ro_token_name].value
+    github_ro_token = module.ecommerce_prod_secrets.values["ecommerce-github-packages-read-bot-token"].value
   }
   # deploy vars
   pagopa-ecommerce-helpdesk-commands-service-variables_deploy = {
@@ -73,7 +73,7 @@ locals {
     tenant_id                    = data.azurerm_client_config.current.tenant_id
     helpdesk_testing_api_key_dev = module.ecommerce_dev_secrets.values["helpdesk-ecommerce-commands-testing-api-key"].value
     helpdesk_testing_api_key_uat = module.ecommerce_uat_secrets.values["helpdesk-ecommerce-commands-testing-api-key"].value
-    github_ro_token = module.secrets.values[local.github_pkg_ro_token_name].value
+    github_ro_token              = module.ecommerce_prod_secrets.values["ecommerce-github-packages-read-bot-token"].value
   }
 }
 

--- a/azure-devops/ecommerce/06_pagopa-ecommerce-helpdesk-service.tf
+++ b/azure-devops/ecommerce/06_pagopa-ecommerce-helpdesk-service.tf
@@ -41,7 +41,7 @@ locals {
   }
   # code_review secrets
   pagopa-ecommerce-helpdesk-service-variables_secret_code_review = {
-    github_ro_token = module.secrets.values[local.github_pkg_ro_token_name].value
+    github_ro_token = module.ecommerce_prod_secrets.values["ecommerce-github-packages-read-bot-token"].value
   }
   # deploy vars
   pagopa-ecommerce-helpdesk-service-variables_deploy = {
@@ -78,7 +78,7 @@ locals {
     helpdesk_testing_fiscalCode_dev    = module.ecommerce_dev_secrets.values["helpdesk-service-testing-fiscalCode"].value
     helpdesk_testing_fiscalCode_uat    = module.ecommerce_uat_secrets.values["helpdesk-service-testing-fiscalCode"].value
     helpdesk_testing_email_history_dev = module.ecommerce_dev_secrets.values["helpdesk-service-testing-email-history"].value
-    github_ro_token                    = module.secrets.values[local.github_pkg_ro_token_name].value
+    github_ro_token                    = module.ecommerce_prod_secrets.values["ecommerce-github-packages-read-bot-token"].value
   }
 }
 

--- a/azure-devops/ecommerce/06_pagopa-ecommerce-payments-methods-service.tf
+++ b/azure-devops/ecommerce/06_pagopa-ecommerce-payments-methods-service.tf
@@ -41,7 +41,7 @@ locals {
   }
   # code_review secrets
   pagopa-ecommerce-payment-methods-service-variables_secret_code_review = {
-    github_ro_token = module.secrets.values[local.github_pkg_ro_token_name].value
+    github_ro_token = module.ecommerce_prod_secrets.values["ecommerce-github-packages-read-bot-token"].value
   }
   # deploy vars
   pagopa-ecommerce-payment-methods-service-variables_deploy = {
@@ -68,10 +68,10 @@ locals {
   }
   # deploy secrets
   pagopa-ecommerce-payment-methods-service-variables_secret_deploy = {
-    tenant_id    = data.azurerm_client_config.current.tenant_id
-    git_mail     = module.secrets.values["azure-devops-github-EMAIL"].value
-    git_username = module.secrets.values["azure-devops-github-USERNAME"].value
-    github_ro_token = module.secrets.values[local.github_pkg_ro_token_name].value
+    tenant_id       = data.azurerm_client_config.current.tenant_id
+    git_mail        = module.secrets.values["azure-devops-github-EMAIL"].value
+    git_username    = module.secrets.values["azure-devops-github-USERNAME"].value
+    github_ro_token = module.ecommerce_prod_secrets.values["ecommerce-github-packages-read-bot-token"].value
   }
 }
 

--- a/azure-devops/ecommerce/06_pagopa-ecommerce-transactions-scheduler-service.tf
+++ b/azure-devops/ecommerce/06_pagopa-ecommerce-transactions-scheduler-service.tf
@@ -41,7 +41,7 @@ locals {
   }
   # code_review secrets
   pagopa-ecommerce-transactions-scheduler-service-variables_secret_code_review = {
-    github_ro_token = module.secrets.values[local.github_pkg_ro_token_name].value
+    github_ro_token = module.ecommerce_prod_secrets.values["ecommerce-github-packages-read-bot-token"].value
   }
   # deploy vars
   pagopa-ecommerce-transactions-scheduler-service-variables_deploy = {
@@ -68,10 +68,10 @@ locals {
   }
   # deploy secrets
   pagopa-ecommerce-transactions-scheduler-service-variables_secret_deploy = {
-    git_mail     = module.secrets.values["azure-devops-github-EMAIL"].value
-    git_username = module.secrets.values["azure-devops-github-USERNAME"].value
-    tenant_id    = data.azurerm_client_config.current.tenant_id
-    github_ro_token = module.secrets.values[local.github_pkg_ro_token_name].value
+    git_mail        = module.secrets.values["azure-devops-github-EMAIL"].value
+    git_username    = module.secrets.values["azure-devops-github-USERNAME"].value
+    tenant_id       = data.azurerm_client_config.current.tenant_id
+    github_ro_token = module.ecommerce_prod_secrets.values["ecommerce-github-packages-read-bot-token"].value
   }
 }
 

--- a/azure-devops/ecommerce/06_pagopa-ecommerce-transactions-service.tf
+++ b/azure-devops/ecommerce/06_pagopa-ecommerce-transactions-service.tf
@@ -41,7 +41,7 @@ locals {
   }
   # code_review secrets
   pagopa-ecommerce-transactions-service-variables_secret_code_review = {
-    github_ro_token = module.secrets.values[local.github_pkg_ro_token_name].value
+    github_ro_token = module.ecommerce_prod_secrets.values["ecommerce-github-packages-read-bot-token"].value
   }
   # deploy vars
   pagopa-ecommerce-transactions-service-variables_deploy = {
@@ -68,10 +68,10 @@ locals {
   }
   # deploy secrets
   pagopa-ecommerce-transactions-service-variables_secret_deploy = {
-    git_mail     = module.secrets.values["azure-devops-github-EMAIL"].value
-    git_username = module.secrets.values["azure-devops-github-USERNAME"].value
-    tenant_id    = data.azurerm_client_config.current.tenant_id
-    github_ro_token = module.secrets.values[local.github_pkg_ro_token_name].value
+    git_mail        = module.secrets.values["azure-devops-github-EMAIL"].value
+    git_username    = module.secrets.values["azure-devops-github-USERNAME"].value
+    tenant_id       = data.azurerm_client_config.current.tenant_id
+    github_ro_token = module.ecommerce_prod_secrets.values["ecommerce-github-packages-read-bot-token"].value
   }
 }
 

--- a/azure-devops/ecommerce/99_locals.tf
+++ b/azure-devops/ecommerce/99_locals.tf
@@ -3,5 +3,4 @@ locals {
   dev_identity_rg_name  = "pagopa-d-identity-rg"
   uat_identity_rg_name  = "pagopa-u-identity-rg"
   prod_identity_rg_name = "pagopa-p-identity-rg"
-  github_pkg_ro_token_name = "azure-devops-github-ro-TOKEN"
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
- added github read only token secret to the ecommerce services' pipelines that have the new github packages ecommerce-commons dependency

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This change was needed to provide the azure devops code review and deploy pipelines with the necessary github token to download the ecommerce-commons library recently published on github packages

### Type of changes

- [ ] Add new pipeline
- [x] Update pipeline configuration
- [ ] Remove pipeline

### :warning: If it's new pipeline with code review have you added pagopa-github-bot -> Role: admin?

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
