### PR TITLE
feat: [CHK-4414] add github read packages token to payment requests cr and deploy pipelines

### DIFF
--- a/azure-devops/ecommerce/06_pagopa-ecommerce-payment-requests-service.tf
+++ b/azure-devops/ecommerce/06_pagopa-ecommerce-payment-requests-service.tf
@@ -41,7 +41,7 @@ locals {
   }
   # code_review secrets
   pagopa-ecommerce-payment-requests-service-variables_secret_code_review = {
-
+    github_ro_token = module.ecommerce_prod_secrets.values["ecommerce-github-packages-read-bot-token"].value
   }
   # deploy vars
   pagopa-ecommerce-payment-requests-service-variables_deploy = {
@@ -68,9 +68,10 @@ locals {
   }
   # deploy secrets
   pagopa-ecommerce-payment-requests-service-variables_secret_deploy = {
-    git_mail     = module.secrets.values["azure-devops-github-EMAIL"].value
-    git_username = module.secrets.values["azure-devops-github-USERNAME"].value
-    tenant_id    = data.azurerm_client_config.current.tenant_id
+    git_mail        = module.secrets.values["azure-devops-github-EMAIL"].value
+    git_username    = module.secrets.values["azure-devops-github-USERNAME"].value
+    tenant_id       = data.azurerm_client_config.current.tenant_id
+    github_ro_token = module.ecommerce_prod_secrets.values["ecommerce-github-packages-read-bot-token"].value
   }
 }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

### List of changes

<!--- Describe your changes in detail -->
- introduced a github packages read-only token secret in the eCommerce payment-requests-service pipelines to support dependency verification (https://github.com/pagopa/depcheck#usage --> `read:packages` token needed)

### Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This change was needed to provide the azure devops code review and deploy pipelines with the necessary github packages readonly token to verify dependencies in pipelines

### Type of changes

- [ ] Add new pipeline
- [x] Update pipeline configuration
- [ ] Remove pipeline

### :warning: If it's new pipeline with code review have you added pagopa-github-bot -> Role: admin?

- [ ] Yes
- [ ] No

### Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

---

### If PR is partially applied, why? (reserved to mantainers)

<!--- Describe the blocking cause -->
