### PR TITLE
fix: Update static analysis action to version 1.26.0

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -11,6 +11,6 @@ jobs:
 
     steps:
       - name: Static Analysis
-        uses: pagopa/eng-github-actions-iac-template/azure/terraform-static-analysis@59c12b7a846423d62c27c9905686a7a1fd71c003 # v1.7.0
+        uses: pagopa/eng-github-actions-iac-template/azure/terraform-static-analysis@c4eb4d7f3b953bdb7e07f7f7ac47a125b0cf0ac7 # v1.26.0
         with:
           precommit_version: 'v1.96.2@sha256:01f870b7689b5a09c1a370914fcddcac42c4b6478c9d369e1d2590dd0a66ffd0'


### PR DESCRIPTION
### List of changes

- Updated the static analysis action to version 1.26.0.

### Motivation and context

- This update ensures compatibility with the latest features and fixes provided in version 1.26.0 of the static analysis action.

### Type of changes

- [ ] Add new pipeline
- [x] Update pipeline configuration
- [ ] Remove pipeline

### :warning: If it's new pipeline with code review have you added pagopa-github-bot -> Role: admin?

- [ ] Yes
- [ ] No

### Other information

N/A

---

### If PR is partially applied, why? (reserved to mantainers)

N/A